### PR TITLE
Add python-oauth2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+python-oauth2


### PR DESCRIPTION
This commit adds a known risky dependency to the requirements.txt file to test minder's trusty integration.